### PR TITLE
Incident-22111 Remove token from logs

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -87,7 +87,7 @@ def _oci_blob_pull_impl(rctx):
             },
         }
 
-    debug(rctx, "pulling from: ", blob_url, ", auth token: ", auths)
+    debug(rctx, "pulling from: ", blob_url)
 
     algo, sha256digest = rctx.attr.digest.split(":")
     if rctx.attr.extract:


### PR DESCRIPTION
## Context

Incident: https://app.datadoghq.com/incidents/22111

We don't want to log the tokens even when debugging. These debug logs
end up showing up in GitLab and k8s, and they contain real usable
tokens. We don't want to leak these tokens accidentally.

We remove the logging of the tokens, since that appears to be where the
leak is.