### PR TITLE
Incident-22111 Use initial successful response

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -79,13 +79,15 @@ def _oci_blob_pull_impl(rctx):
         }
     else:
         result = rctx.execute([rctx.path(rctx.attr.token_handler), registry, rctx.attr.repository])
-        data = struct(**json.decode(result.stdout))
-        auths = {
-            blob_url: {
-                "type": "pattern",
-                "pattern": "Bearer {}".format(data.token),
-            },
-        }
+        data = json.decode(result.stdout)
+        token = data.get("token")
+        if token != None:
+            auths = {
+                blob_url: {
+                    "type": "pattern",
+                    "pattern": "Bearer {}".format(token),
+                },
+            }
 
     debug(rctx, "pulling from: ", blob_url)
 

--- a/token.py
+++ b/token.py
@@ -111,7 +111,7 @@ def get_auth_token_for_registry(registry, repository):
     token_uri = ""
     try:
         response = urllib.request.urlopen('https://{}/v2/'.format(registry))
-        return None
+        return json.loads(response.read())
     except urllib.error.URLError as e:
         if e.code != 401:
             raise e


### PR DESCRIPTION
## Context

Incident: https://app.datadoghq.com/incidents/22111

We noticed that in some cases, the initial call to the registry seems to
work, but we were ignoring the response we received instead of using it.
We change it so we now use the response we received.

However just because we received a response, doesn't mean that it has
useful data in it. On the other end, we have to check if the response
actually has a token in it. If it doesn't, we don't do anything with it.

## Testing

We should add a test to validate that using a registry that succeeds on
the initial request works.