### PR TITLE
LANGTOOLS Remove whitespace

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -44,7 +44,7 @@ def _get_registry_auth(rctx, registry):
     script = """
     #!/bin/bash
     echo {registry} | docker-credential-{helper} get
-    """.format(registry = registry, helper = helper)
+    """.format(registry = registry, helper = helper).strip()
 
     res = _execute_script(rctx, script)
     if res.return_code > 0:


### PR DESCRIPTION
The extra whitespace causes issues on some machines. We remove it with a `strip`