### PR TITLE
Fix DOCKER_CONFIG env var being ignored

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -18,7 +18,7 @@ def _read_cred_helpers(rctx):
     raw_config_path = rctx.os.environ["HOME"] + "/.docker/config.json"
     docker_config_env = rctx.os.environ.get("DOCKER_CONFIG")
     if docker_config_env != None:
-        raw_config_path_base = docker_config_env + "/config.json"
+        raw_config_path = docker_config_env + "/config.json"
 
     debug(rctx, "reading docker config from: ", raw_config_path)
 


### PR DESCRIPTION
## Summary
- `_read_cred_helpers` assigns the `DOCKER_CONFIG` override to `raw_config_path_base` (dead variable) instead of `raw_config_path`
- Config path always resolves to `$HOME/.docker/config.json` regardless of `DOCKER_CONFIG`
- fix: `raw_config_path_base` → `raw_config_path`


🤖 Generated with [Claude Code](https://claude.ai/claude-code)